### PR TITLE
Fix download button to download post.png and improve popup text visibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,13 +41,13 @@
     <dialog id="my_modal_1" class="modal">
       <div class="modal-box">
         <h3 class="text-lg font-bold"></h3>
-        <p class="py-4" id="winner-text">congrats you got</p>
+        <p class="py-4" id="winner-text" style="font-size: 20px;">congrats you got</p>
         <img src="post.png" alt="">
         <div class="modal-action">
           <form method="dialog">
             <button class="btn">Close</button>
           </form>
-          <button id="download-btn" download>Download Image</button>
+          <button id="download-btn" download="post.png">Download Image</button>
         </div>
       </div>
     </dialog>

--- a/index.js
+++ b/index.js
@@ -130,7 +130,7 @@ document.getElementById("download-btn").addEventListener("click", function() {
   // Create a temporary link element
   const tempLink = document.createElement("a");
   tempLink.href = imageDataURL;
-  tempLink.download = "wheel_image.png";
+  tempLink.download = "post.png";
 
   // Trigger the download
   tempLink.click();

--- a/styles.css
+++ b/styles.css
@@ -121,3 +121,8 @@
 #download-btn:hover {
     background-color: #45a049; /* Darker green on hover */
 }
+
+/* Increase the font size of the text in the popup */
+.modal-box p {
+    font-size: 24px;
+}


### PR DESCRIPTION
Update the download button to download `post.png` and improve the visibility of the text on the popup.

* **index.html**
  - Update the `download` attribute of the `download-btn` to download `post.png`.
  - Increase the font size of the text in the popup to make it more visible.

* **index.js**
  - Update the event listener for the `download-btn` to download `post.png` instead of `wheel_image.png`.

* **styles.css**
  - Increase the font size of the text in the popup to make it more visible.

